### PR TITLE
Allow empty message

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -54,7 +54,7 @@ The request-body must have the `notifications` array. Table below shows the para
 |-----------------|------------|-----------------------------------------|--------|-------|------------------------------------------|
 |token            |string array|device tokens                            |o       |       |                                          |
 |platform         |int         |platform(iOS, Android)                   |o       |       |1=iOS, 2=Android                          |
-|message          |string      |message for notification                 |o       |       |                                          |
+|message          |string      |message for notification                 |-       |       |                                          |
 |title            |string      |title for notification                   |-       |       |only iOS                                  |
 |subtitle         |string      |subtitle for notification                |-       |       |only iOS                                  |
 |badge            |int         |badge count                              |-       |0      |only iOS                                  |

--- a/conf/gaurun.toml
+++ b/conf/gaurun.toml
@@ -6,6 +6,7 @@ queues = 8192
 notification_max = 100
 shutdown_timeout = 30
 # pid = "/tmp/gaurun.pid"
+# allows_empty_message = true
 
 [android]
 apikey = "apikey for FCM"

--- a/gaurun/conf.go
+++ b/gaurun/conf.go
@@ -18,13 +18,14 @@ type ConfToml struct {
 }
 
 type SectionCore struct {
-	Port            string `toml:"port"`
-	WorkerNum       int64  `toml:"workers"`
-	QueueNum        int64  `toml:"queues"`
-	NotificationMax int64  `toml:"notification_max"`
-	PusherMax       int64  `toml:"pusher_max"`
-	ShutdownTimeout int64  `toml:"shutdown_timeout"`
-	Pid             string `toml:"pid"`
+	Port               string `toml:"port"`
+	WorkerNum          int64  `toml:"workers"`
+	QueueNum           int64  `toml:"queues"`
+	NotificationMax    int64  `toml:"notification_max"`
+	PusherMax          int64  `toml:"pusher_max"`
+	ShutdownTimeout    int64  `toml:"shutdown_timeout"`
+	Pid                string `toml:"pid"`
+	AllowsEmptyMessage bool   `toml:"allows_empty_message"`
 }
 
 type SectionAndroid struct {
@@ -67,6 +68,7 @@ func BuildDefaultConf() ConfToml {
 	conf.Core.PusherMax = 0
 	conf.Core.ShutdownTimeout = 10
 	conf.Core.Pid = ""
+	conf.Core.AllowsEmptyMessage = false
 	// Android
 	conf.Android.ApiKey = ""
 	conf.Android.Enabled = true

--- a/gaurun/conf_test.go
+++ b/gaurun/conf_test.go
@@ -37,6 +37,7 @@ func (suite *ConfigTestSuite) TestValidateConfDefault() {
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Core.NotificationMax, int64(100))
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Core.PusherMax, int64(0))
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Core.Pid, "")
+	assert.Equal(suite.T(), suite.ConfGaurunDefault.Core.AllowsEmptyMessage, false)
 	// Android
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.Enabled, true)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.ApiKey, "")
@@ -68,6 +69,7 @@ func (suite *ConfigTestSuite) TestValidateConf() {
 	assert.Equal(suite.T(), suite.ConfGaurun.Core.NotificationMax, int64(100))
 	assert.Equal(suite.T(), suite.ConfGaurun.Core.PusherMax, int64(0))
 	assert.Equal(suite.T(), suite.ConfGaurun.Core.Pid, "")
+	assert.Equal(suite.T(), suite.ConfGaurun.Core.AllowsEmptyMessage, false)
 	// Android
 	assert.Equal(suite.T(), suite.ConfGaurun.Android.Enabled, true)
 	assert.Equal(suite.T(), suite.ConfGaurun.Android.ApiKey, "apikey for FCM")

--- a/gaurun/notification.go
+++ b/gaurun/notification.go
@@ -165,6 +165,10 @@ func validateNotification(notification *RequestGaurunNotification) error {
 		return errors.New("invalid platform")
 	}
 
+	if !ConfGaurun.Core.AllowsEmptyMessage && len(notification.Message) == 0 {
+		return errors.New("empty message")
+	}
+
 	if notification.PushType != "" {
 		if notification.PushType != ApnsPushTypeAlert && notification.PushType != ApnsPushTypeBackground {
 			return fmt.Errorf("push_type must be %s or %s", ApnsPushTypeAlert, ApnsPushTypeBackground)

--- a/gaurun/notification.go
+++ b/gaurun/notification.go
@@ -165,10 +165,6 @@ func validateNotification(notification *RequestGaurunNotification) error {
 		return errors.New("invalid platform")
 	}
 
-	if len(notification.Message) == 0 {
-		return errors.New("empty message")
-	}
-
 	if notification.PushType != "" {
 		if notification.PushType != ApnsPushTypeAlert && notification.PushType != ApnsPushTypeBackground {
 			return fmt.Errorf("push_type must be %s or %s", ApnsPushTypeAlert, ApnsPushTypeBackground)

--- a/gaurun/notification_test.go
+++ b/gaurun/notification_test.go
@@ -80,7 +80,7 @@ func TestValidateNotification(t *testing.T) {
 				Platform: 1,
 				Message:  "",
 			},
-			nil,
+			errors.New("empty message"),
 		},
 		{
 			RequestGaurunNotification{
@@ -97,6 +97,21 @@ func TestValidateNotification(t *testing.T) {
 		actual := validateNotification(&c.Notification)
 		assert.Equal(t, actual, c.Expected)
 	}
+}
+
+func TestValidateNotificationWithAllowingEmptyMessage(t *testing.T) {
+	allowsEmptyBefore := ConfGaurun.Core.AllowsEmptyMessage
+	ConfGaurun.Core.AllowsEmptyMessage = true
+	defer func() {
+		ConfGaurun.Core.AllowsEmptyMessage = allowsEmptyBefore
+	}()
+	notification := RequestGaurunNotification{
+		Tokens:   []string{"test token"},
+		Platform: 1,
+		Message:  "",
+	}
+
+	assert.Nil(t, validateNotification(&notification))
 }
 
 func TestSendResponse(t *testing.T) {

--- a/gaurun/notification_test.go
+++ b/gaurun/notification_test.go
@@ -80,7 +80,7 @@ func TestValidateNotification(t *testing.T) {
 				Platform: 1,
 				Message:  "",
 			},
-			errors.New("empty message"),
+			nil,
 		},
 		{
 			RequestGaurunNotification{


### PR DESCRIPTION
I'd like to send push notification with empty message.
Apple and FCM don't say that message body is required.

use case:
I'd like to update badge count on iOS by sending push notifications without showing any alert to users.
To do this, I should send push notifications with empty body.

Apple's document:
https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html#//apple_ref/doc/uid/TP40008194-CH17-SW5

FCM' document:
https://firebase.google.com/docs/cloud-messaging/http-server-ref#notification-payload-support